### PR TITLE
Handle mixed keys (symbol/string) in params

### DIFF
--- a/lib/grape-apiary/route.rb
+++ b/lib/grape-apiary/route.rb
@@ -5,8 +5,10 @@ module GrapeApiary
     delegate :route_namespace, :route_path, :route_method, to: '__getobj__'
 
     def route_params
-      @route_params ||= __getobj__.route_params.sort.map do |param|
-        Parameter.new(self, *param)
+      @route_params ||= begin
+        __getobj__.route_params.stringify_keys.sort.map do |param|
+          Parameter.new(self, *param)
+        end
       end
     end
 


### PR DESCRIPTION
An issue was reported in #7 that illustrated an error when the params hash had a mix of string and symbol keys. Ultimately it appears that grape-entity is creating this inconsistent hash but normalizing the
keys resolves the error.

NOTE: I was not able to reproduce this error in specs because grape-entity is not included in this project however I did reproduce and test the fix externally.