### PR TITLE
Update supported Ruby versions and dependencies

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,7 +37,7 @@ Style/ElseAlignment:
   Enabled: false
 
 Lint/EndAlignment:
-  AlignWith: variable
+  EnforcedStyleAlignWith: variable
 
 ClassAndModuleChildren:
   # ok to use compact style when modules are predefined.
@@ -46,3 +46,9 @@ ClassAndModuleChildren:
   #
   # class Foo::Bar; end
   Enabled: false
+
+Metrics/BlockLength:
+  # Certain DSL use blocks and can be lengthy
+  Exclude:
+    - 'grape-apiary.gemspec'
+    - 'spec/**/*'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: ruby
+before_install:
+  - gem update --system
 cache: bundler
 rvm:
-  - 2.3.0
-  - 2.2.4
-  - 2.1.8
-  - jruby
+  - 2.4.0
+  - 2.3.3
+  - 2.2.6
+  - jruby-9.1.2.0
 env:
   - CODECLIMATE_REPO_TOKEN=7522ea83858a08d70747c1f5fb0593502ca0e43c18b6a124dbeb72a0b0e78262

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,24 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## 0.1.1 (2016-01-25)
+## Recent updates
+
+- [PR #14](https://github.com/technekes/grape-apiary/pull/14) - Update supported Ruby versions and dependencies [@jallen3d](https://github.com/johnallen3d).
+
+## 0.1.2 (2016-01-25)
+
 #### Hotfix
+
 - Lock down grape dependency to prior to 0.16 because of internal change [@jallen3d](https://github.com/johnallen3d).
 
-## 0.1.1 (2016-01-25)
 #### Fixes
+
 - [PR #8](https://github.com/technekes/grape-apiary/pull/8) - Handle mixed keys (symbol/string) in params [@jallen3d](https://github.com/johnallen3d).
 
 ## 0.1.0 (2016-01-25)
+
 #### Features
+
 - [PR #5](https://github.com/technekes/grape-apiary/pull/5) - Rake task persists docs to disk from [@bigfleet](https://github.com/bigfleet).
 
 ## 0.0.1 - 0.0.4 (2014-02-10)


### PR DESCRIPTION
* Update supported Ruby versions
* Update RuboCop config for latest version
* Upgrade RubyGems before build - Some gem(s) (rainbows) are failing to install with the prior version.
* Update CHANGELOG